### PR TITLE
ReadMe Python version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Whisper Input 是受到即友[FeiTTT](https://web.okjike.com/u/DB98BE7A-9DBB-473
 
 ### 前提
 请确保你的本地有 Python 环境，并且 Python 版本不低于 3.10。
+#### 3.13.1会有光标切换窗口报错的问题，这是个known issue，暂无解决方案，3.12.5无报错
 
 ### FunAudioLLM/SenseVoiceSmall 模型配置方法
 1. 注册 SiliconFlow 账户：https://cloud.siliconflow.cn/i/RXikvHE2


### PR DESCRIPTION
<img width="1198" alt="Screenshot 2025-01-26 at 7 34 30 PM" src="https://github.com/user-attachments/assets/862b4a81-0a31-4b8e-9e71-d0f27b9f5c88" />

最新Python 3.13.1会有光标切换窗口报错的问题，这是个known issue，暂无解决方案，3.12.5亲测无报错。

（内心sos： 主要是相当contributer）